### PR TITLE
Fix blank image

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -155,7 +155,7 @@ return [
     |
     */
 
-    'blank_image'                 => 'packages/maxxscho/laravel-tcpdf/_blank.png',
+    'blank_image'                 => 'packages/maxxscho/laravel-tcpdf/images/_blank.png',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
The path to the blank image was missing the /images/ directory.
