### PR TITLE
Resolves composer warning about tecnick.com/tcpdf being abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "~4",
-        "tecnick.com/tcpdf": "6.*"
+        "tecnickcom/tcpdf": "6.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
`Package tecnick.com/tcpdf is abandoned, you should avoid using it. Use tecnickcom/tcpdf instead`