### PR TITLE
allow parent Header function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ PDF::Write(0, 'Hello World');
 
 PDF::Output('hello_world.pdf');
 ```
-For a list of all available function take a look at the [TCPDF Documentation](http://www.tcpdf.org/doc/code/classTCPDF.html)
+For a list of all available function take a look at the [TCPDF Documentation](https://tcpdf.org/docs/srcdoc/TCPDF/classes-TCPDF/)
 
 ## Configuration
 
@@ -78,9 +78,11 @@ vendor/maxxscho/laravel-tcpdf/vendor/tecnick.com/tcpdf/tools/tcpdf_addfont.php -
 This uses a little tool provided by TCPDF to convert fonts for TCPDF.
 The `-i` flag is for the input fonts (comma-separated list)
 and the `-o` flag is for the output directory.
-Read here all about [TCPDF fonts](http://www.tcpdf.org/fonts.php) and how to convert them [the new way](http://queirozf.com/entries/adding-a-custom-font-to-tcpdf).
+Read here all about [TCPDF fonts](https://tcpdf.org/docs/srcdoc/TCPDF/classes-TCPDF-FONTS/) ([TCPDF old font doku](https://web.archive.org/web/20160306033331/http://www.tcpdf.org/fonts.php)) and how to convert them [the new way](http://queirozf.com/entries/adding-a-custom-font-to-tcpdf).
 
 
 ## Custom Header
-"`PDF::setHtmlHeader($custom_header);
-  PDF::Header();`"
+```
+  PDF::setHtmlHeader($custom_header);
+  PDF::AddPage();
+```

--- a/src/Maxxscho/LaravelTcpdf/LaravelTcpdf.php
+++ b/src/Maxxscho/LaravelTcpdf/LaravelTcpdf.php
@@ -6,7 +6,8 @@ use Config;
 
 class LaravelTcpdf extends TCPDF
 {
-    var $htmlHeader; //holds custom header string/html
+    var $htmlHeader; // holds custom header string/html
+    
     /**
      * TCPDF system constants that map to settings in our config file
      *
@@ -168,10 +169,13 @@ class LaravelTcpdf extends TCPDF
     public function setHtmlHeader($htmlHeader) {
         $this->htmlHeader = $htmlHeader;
     }
-    //Customize according to your specification
-    public function Header() {
-        $this->WriteHTML($this->htmlHeader, true,false, false, false,'L'); 
 
+    /**
+     * Customize html header according to your specification or use parent TCPDF header function
+     */
+    public function Header() {
+        if (empty($this->htmlHeader)) parent::Header();
+        else $this->WriteHTML($this->htmlHeader, true,false, false, false,'L');
     }
 
 }


### PR DESCRIPTION
The parent Header() function of TCPDF has been overridden and could not be used anymore. Now the Header() function of laravel-tcpdf is used only if the htmlHeader string is set.
This allows the use of the TCPDF header or the laravel-tcpdf custom header.

This package is for Laravel 4 but I still have old Laravel projects which use laravel-tcpdf.

The master branch is needed to replace tecnick.com/tcpdf ([abandoned](https://packagist.org/packages/tecnick.com/tcpdf)) by tecnickcom/tcpdf. 